### PR TITLE
Remote https:// from IP address output

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -4,5 +4,5 @@ output "catapp_url" {
 }
 
 output "catapp_ip" {
-  value = "http://${azurerm_public_ip.catapp-pip.ip_address}"
+  value = azurerm_public_ip.catapp-pip.ip_address
 }


### PR DESCRIPTION
the output is called catapp_ip.  if you put an https:// it is technically a URI and not an ip address