### PR TITLE
fix: getting dynamic ip from azure requires to fetch it again

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -109,6 +109,12 @@ resource "azurerm_public_ip" "catapp-pip" {
   domain_name_label   = "${var.prefix}-meow"
 }
 
+data "azurerm_public_ip" "catapp-pip" { 
+  depends_on = [ azurerm_public_ip.catapp-pip ]
+  name                = "${var.prefix}-ip"
+  resource_group_name = azurerm_resource_group.myresourcegroup.name
+}
+
 resource "azurerm_linux_virtual_machine" "catapp" {
   name                            = "${var.prefix}-meow"
   location                        = azurerm_resource_group.myresourcegroup.location

--- a/outputs.tf
+++ b/outputs.tf
@@ -7,5 +7,5 @@ output "catapp_url" {
 }
 
 output "catapp_ip" {
-  value = "http://${azurerm_public_ip.catapp-pip.ip_address}"
+  value = "http://${data.azurerm_public_ip.catapp-pip.ip_address}"
 }


### PR DESCRIPTION
azure public ip needs to be fetched again after resource creation to be able to read that information in following instructions.

so the output with the ip address becomes available and useful